### PR TITLE
STRY0019945 - DFCT - Fix arborator output of cluster_summary so missing values appear as blank instead of nan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- A problem with summarizing metadata when all entries are missing. [PR 37](https://github.com/phac-nml/arborator/pull/37)
+
 ## [1.2.1] - 2025-01-12
 
 ### Fixed

--- a/arborator/classes/aggregator.py
+++ b/arborator/classes/aggregator.py
@@ -66,10 +66,10 @@ class summarizer:
 
     def calc_desc_stats_numerical(self,values):
         s = {
-            'min':0,
-            'median':0,
-            'mean':0,
-            'max':0,
+            'min':'nan',
+            'median':'nan',
+            'mean':'nan',
+            'max':'nan',
         }
         if len(values) > 0:
             s = {
@@ -83,10 +83,10 @@ class summarizer:
     def calc_desc_stats_dates(self,values):
         values = sorted(self.convert_date(values))
         s = {
-            'min': '',
-            'median': '',
-            'mean': '',
-            'max': '',
+            'min': 'nan',
+            'median': 'nan',
+            'mean': 'nan',
+            'max': 'nan',
         }
         if len(values) > 0:
             s = {

--- a/arborator/classes/report.py
+++ b/arborator/classes/report.py
@@ -20,7 +20,9 @@ class report:
                 'value_counts': {},
                 'shannon_entropy': -1,
             }
-            unique_values = dict(df[col].astype(str).value_counts())
+            unique_values = df[col].value_counts(dropna=True)
+            unique_values.index = unique_values.index.astype(str)
+            unique_values = dict(unique_values)
 
             if missing_data in unique_values:
                 locus['num_missing'] = unique_values[missing_data]

--- a/tests/data/config_no_metadata.json
+++ b/tests/data/config_no_metadata.json
@@ -1,0 +1,34 @@
+{
+    "outlier_thresh": "25",
+    "method": "average",
+    "thresholds": "10,5,2,1,0",
+    "min_members": 2,
+    "partition_col": "outbreak",
+    "id_col": "sample_name",
+    "only_report_labeled_columns": "False",
+    
+    "grouped_metadata_columns":{ 
+        "outbreak": { "data_type": "None", "label": "Outbreak Code", "default": "", "display": "True" },
+        "organism": { "data_type": "None", "label": "Organism", "default": "", "display": "True" },
+        "subtype": { "data_type": "None", "label": "Subtype", "default": "", "display": "True" },
+        "country": { "data_type": "Categorical", "label": "Country of Collection", "default": "", "display": "True" },
+        "serovar": { "data_type": "Categorical", "label": "Serovar", "default": "", "display": "True" },
+        "age": { "data_type": "desc_stats", "label": "Patient Age (years)", "default": "", "display": "True" },
+        "date": { "data_type": "min_max", "label": "Date", "default": "", "display": "True" },
+        "source": { "data_type": "Categorical", "label": "Source Type", "default": "", "display": "True" },
+        "special": { "data_type": "Categorical", "label": "Special", "default": "", "display": "True" }
+    },
+
+    "linelist_columns":{
+        "sample_name": { "data_type": "None", "label": "Sample", "default": "", "display": "True" },
+        "outbreak": { "data_type": "None", "label": "Outbreak Code", "default": "", "display": "True" },
+        "organism": { "data_type": "None", "label": "Organism", "default": "", "display": "True" },
+        "subtype": { "data_type": "None", "label": "Subtype", "default": "", "display": "True" },
+        "country": { "data_type": "Categorical", "label": "Country of Collection", "default": "", "display": "True" },
+        "serovar": { "data_type": "Categorical", "label": "Serovar", "default": "", "display": "True" },
+        "age": { "data_type": "desc_stats", "label": "Patient Age (years)", "default": "", "display": "True" },
+        "date": { "data_type": "min_max", "label": "Date", "default": "", "display": "True" },
+        "source": { "data_type": "Categorical", "label": "Source Type", "default": "", "display": "True" },
+        "special": { "data_type": "Categorical", "label": "Special", "default": "", "display": "True" }
+    }
+}

--- a/tests/data/metadata_no_metadata.tsv
+++ b/tests/data/metadata_no_metadata.tsv
@@ -1,0 +1,7 @@
+sample_name	sample	outbreak	organism	subtype	country	serovar	age	date	source	special
+S1	S1	1								
+S2	S2	1								
+S3	S3	2								
+S4	S4	2								
+S5	S5	3								
+S6	S6	unassociated								

--- a/tests/data/profile_no_metadata.tsv
+++ b/tests/data/profile_no_metadata.tsv
@@ -1,0 +1,7 @@
+sample_id	locus_1	locus_2	locus_3	locus_4	locus_5	locus_6	locus_7
+S1	1	1	1	1	1	1	1
+S2	1	1	2	2	?	4	1
+S3	1	2	2	2	1	5	1
+S4	1	2	3	2	1	6	1
+S5	1	2	?	2	1	8	1
+S6	2	3	3	-	?	9	0

--- a/tests/test-workflows.yml
+++ b/tests/test-workflows.yml
@@ -2135,7 +2135,7 @@
   tags:
     - unsorted_profile
     - sorted_unsorted
-  command: arborator --profile tests/data/profile_unsorted.tsv --metadata tests/data/metadata_sorted_unsorted.tsv --config tests/data/config_sorted_unsorted.json  --sort_matrix --outdir results
+  command: arborator --profile tests/data/profile_unsorted.tsv --metadata tests/data/metadata_sorted_unsorted.tsv --config tests/data/config_sorted_unsorted.json --sort_matrix --outdir results
   stdout:
     must_not_contain:
       - "parameter unrecognized"
@@ -2153,3 +2153,40 @@
         - "1_outgroup_17\t1|5.5.5.5.8.9"
         - "1_outgroup_18\t1|3.3.3.3.6.7"
         - "1_outgroup_19\t1|6.6.6.6.9.10"
+
+- name: No Metadata
+  tags:
+    - metadata
+    - metadata_no_metadata
+  command: arborator --profile tests/data/profile_no_metadata.tsv --metadata tests/data/metadata_no_metadata.tsv --config tests/data/config_no_metadata.json --outdir results
+  stdout:
+    must_not_contain:
+      - "parameter unrecognized"
+  files:
+    - path: "results/cluster_summary.tsv"
+      contains:
+        - "Outbreak Code\tOrganism\tSubtype\tCountry of Collection\tSerovar\tPatient Age (years)\tDate\tSource Type\tSpecial\tage_max_value\tage_mean_value\tage_median_value\tage_min_value\tcount_members\tcount_outliers\tcount_sample_S1\tcount_sample_S2\tcount_sample_S3\tcount_sample_S4\tcount_sample_S5\tcount_sample_S6\tdate_max_value\tdate_min_value\tmax_dist\tmean_dist\tmedian_dist\tmin_dist\toutlier_ids\tsample"
+        - "1\t\t\t\t\t\t\t\t\tnan\tnan\tnan\tnan\t2\t0\t1\t1\t0\t0\t0\t0\tnan\tnan\t3.0\t3.0\t3.0\t3.0\t\tS1,S2"
+        - "2\t\t\t\t\t\t\t\t\tnan\tnan\tnan\tnan\t2\t0\t0\t0\t1\t1\t0\t0\tnan\tnan\t2.0\t2.0\t2.0\t2.0\t\tS3,S4"
+        - "3\t\t\t\t\t\t\t\t\tnan\tnan\tnan\tnan\t1\t0\t0\t0\t0\t0\t1\t0\tnan\tnan\t0\t0\t0\t0\t\tS5"
+        - "unassociated\t\t\t\t\t\t\t\t\tnan\tnan\tnan\tnan\t1\t0\t0\t0\t0\t0\t0\t1\tnan\tnan\t0\t0\t0\t0\t\tS6"
+    - path: "results/cluster_summary.xlsx"
+    - path: "results/metadata.included.tsv"
+      contains:
+        - "Sample\tOutbreak Code\tOrganism\tSubtype\tCountry of Collection\tSerovar\tPatient Age (years)\tDate\tSource Type\tSpecial\tgas_denovo_cluster_address"
+        - "S1\t1\t\t\t\t\t\t\t\t\t1|1.1.1.1.1"
+        - "S2\t1\t\t\t\t\t\t\t\t\t1|1.1.2.2.2"
+        - "S3\t2\t\t\t\t\t\t\t\t\t2|1.1.1.1.1"
+        - "S4\t2\t\t\t\t\t\t\t\t\t2|1.1.1.2.2"
+        - "S5\t3\t\t\t\t\t\t\t\t\t"
+        - "S6\tunassociated\t\t\t\t\t\t\t\t\t"
+    - path: "results/metadata.included.xlsx"
+    - path: "results/metadata.overlap.tsv"
+      contains:
+        - "sample_name\tsample\toutbreak\torganism\tsubtype\tcountry\tserovar\tage\tdate\tsource\tspecial"
+        - "S1\tS1\t1\t\t\t\t\t\t\t\t"
+        - "S2\tS2\t1\t\t\t\t\t\t\t\t"
+        - "S3\tS3\t2\t\t\t\t\t\t\t\t"
+        - "S4\tS4\t2\t\t\t\t\t\t\t\t"
+        - "S5\tS5\t3\t\t\t\t\t\t\t\t"
+        - "S6\tS6\tunassociated\t\t\t\t\t\t\t\t"


### PR DESCRIPTION
**Description**

As a data analyst, I would like the cluster_summary spreadsheet produced by arborator to use blank cells for missing values instead of nan, so that missing data is represented consistently.

**Acceptance Criteria**

- [x] Fix arborator so output "cluster_summary.tsv" and "cluster_summary.xlsx" use blank values for missing data instead of nan.
- [x] Add test cases for this behaviour.