### PR TITLE
Changes to improve run-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-01-30
+
+### Modified
+
+- Modified `remove_columns` function in `main.py` to perform calculating the percentage of missing alleles at each locus when `--missing_thresh` is between `0-1`. `1`,the default, no columns are dropped, and the calculation is unnecessary. The `--missing_thresh` parameter is currently an unused, and `remove_columns` is currently never performed. We are maintaining support for future functionality of `--missing_thresh`.
+
 ## [1.2.1] - 2025-01-12
 
 ### Fixed

--- a/arborator/main.py
+++ b/arborator/main.py
@@ -644,7 +644,6 @@ def cluster_reporter(config):
         os.makedirs(outdir, 0o755)
 
     (allele_map, profile_df) = process_profile(profile_file, column_mapping={})
-    #profile_df = profile_df.copy()
     profile_df.insert(0, id_col, profile_df.index.to_list())
 
     #write allele mapping file

--- a/arborator/main.py
+++ b/arborator/main.py
@@ -203,18 +203,22 @@ def parse_args():
     return parser.parse_args()
 
 def remove_columns(df,missing_value,max_missing_frac=1):
-    columns = list(df.columns)
-    columns_to_remove = []
-    num_records = len(df)
-    for col in columns:
-        unique_values = dict(df[col].astype(str).value_counts())
-        if missing_value in unique_values:
-            n = unique_values[missing_value]
-            frac = n / num_records
-            if frac > max_missing_frac:
-                columns_to_remove.append(col)
+    if max_missing_frac != 1:
+        columns = list(df.columns)
+        columns_to_remove = []
+        num_records = len(df)
+        for col in columns:
+            unique_values = dict(df[col].astype(str).value_counts())
+            if missing_value in unique_values:
+                n = unique_values[missing_value]
+                frac = n / num_records
+                if frac > max_missing_frac:
+                    columns_to_remove.append(col)
 
-    return df.drop(columns_to_remove, axis=1)
+        return df.drop(columns_to_remove, axis=1)
+    else:
+        columns_to_remove = []
+        return df.drop(columns_to_remove, axis=1)
 
 def get_pairwise_outliers(distance_matrix, thresh):
     # Upper triangle of matrix to avoid duplicates:

--- a/arborator/main.py
+++ b/arborator/main.py
@@ -644,7 +644,7 @@ def cluster_reporter(config):
         os.makedirs(outdir, 0o755)
 
     (allele_map, profile_df) = process_profile(profile_file, column_mapping={})
-    profile_df = profile_df.copy()
+    #profile_df = profile_df.copy()
     profile_df.insert(0, id_col, profile_df.index.to_list())
 
     #write allele mapping file

--- a/arborator/version.py
+++ b/arborator/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.2.2-beta'
+__version__ = '1.2.2'

--- a/arborator/version.py
+++ b/arborator/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.2.1'
+__version__ = '1.2.2-beta'


### PR DESCRIPTION
After some profiling of arborator on a large dataset, approximately 40k samples, using py-spy (runtime) and memray (memory usage) where runtime of the dataset (`--n_threads 1`) was:

```
Job Wall-clock time: 10:29:55
Memory Utilized: 147.72 GB
```
One clear low hanging fruit stood out which is the `remove_columns()` which is currently not in use due to`max_missing_fac()` be unused. When this function is not used:
```
Job Wall-clock time: 08:51:44
Memory Utilized: 45.47 GB
```
During the investigation for other possible gains I noticed a redundant `profile_df = profile_df.copy()` and removed this, but made no real difference to runtime or memory usage.

No new tests were added because it doesn't not make any change to the actual running of `arborator`