### PR TITLE
STRY0017767 - Add support for both hamming and scaled distance comparisons in arborator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Support for a "scaled" distance option, in addition to the default "hamming" distance option. The Hamming distance between two profiles is the number of loci that are different. The scaled distance between two profiles is the percentage of loci that are different, expressed between [0, 100]. [PR #40](https://github.com/phac-nml/arborator/pull/40)
+
 ## [1.2.2] - 2026-01-30
 
 ### Modified

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The parameters are explained as follows:
 - `--missing_thresh`: (UNUSED) Maximum percentage of missing data allowed per locus (0 - 1)
 - `--thresholds` (`t`): vector of threshold levels for clustering
 - `--method` (`-e`): clustering method
+- `--distm`: the method for measuring distance between two profiles (`hamming` or `scaled`)
 - `--tree_distances`: whether GAS interprets distance matrices distances as either `cophenetic` or `patristic`
 - `--sort_matrix`: whether GAS sorts the sample IDs in the distance matrix, which rarely has an effect on cluster assignments when tie-breaking between equal distances during clustering
 - `--force` (`-f`): overwrite existing output results

--- a/arborator/main.py
+++ b/arborator/main.py
@@ -9,7 +9,7 @@ from statistics import mean, median
 import shutil
 from arborator.version import __version__
 from arborator.classes.aggregator import summarizer
-from profile_dists.utils import convert_profiles, calc_distances_hamming, process_profile
+from profile_dists.utils import convert_profiles, calc_distances_hamming, calc_distances_scaled, process_profile
 from arborator.classes.read_data import read_data
 from arborator.classes.report import report
 from arborator.classes.split_profiles import split_profiles
@@ -129,6 +129,11 @@ TRUE_STRINGS = ["t", "true"]
 # Expected to check lowercase:
 FALSE_STRINGS = ["f", "false"]
 
+# Distance Methods:
+HAMMING_DISTANCE = "hamming"
+SCALED_DISTANCE = "scaled"
+DISTANCE_METHODS = [HAMMING_DISTANCE, SCALED_DISTANCE]
+
 def parse_args():
     """ Argument Parsing method.
 
@@ -176,7 +181,9 @@ def parse_args():
                         action='store_true')
     parser.add_argument(MISSING_THRESHOLD_LONG, type=float, required=False,
                         help='UNUSED: Maximum percentage of missing data allowed per locus (0 - 1)')
-    parser.add_argument(DISTANCE_METHOD_LONG, type=str, required=False, help='UNUSED: Distance method raw hamming or scaled difference [hamming, scaled]')
+    parser.add_argument(DISTANCE_METHOD_LONG, type=str, required=False,
+                        help='The distance method to use: raw hamming or scaled difference.',
+                        choices=DISTANCE_METHODS, default=HAMMING_DISTANCE)
     parser.add_argument(SKIP_QC_LONG, SKIP_QC_SHORT, required=False, help='UNUSED: Skip QA/QC steps',
                         action='store_true')
     #GAS
@@ -298,7 +305,7 @@ def stage_data(groups, outdir, metadata_df, id_col, group_file_mapping, max_miss
 
     return files
 
-def process_data(group_files, id_col, group_col, thresholds, outlier_thresh, method, min_members,
+def process_data(group_files, id_col, group_col, thresholds, outlier_thresh, cluster_method, distance_method, min_members,
                  tree_distance_representation, sort_matrix, num_cpus=1):
     try:
         sys_num_cpus = len(os.sched_getaffinity(0))
@@ -313,7 +320,7 @@ def process_data(group_files, id_col, group_col, thresholds, outlier_thresh, met
     results = []
     for group_id in group_files:
         results.append(pool.apply_async(process_group, (group_id, group_files[group_id], id_col, group_col, thresholds,
-                                                        outlier_thresh, method, tree_distance_representation, sort_matrix,
+                                                        outlier_thresh, cluster_method, distance_method, tree_distance_representation, sort_matrix,
                                                         min_members)))
 
     pool.close()
@@ -329,7 +336,7 @@ def process_data(group_files, id_col, group_col, thresholds, outlier_thresh, met
     return r
 
 def process_group(group_id, output_files, id_col, group_col, thresholds,
-                  outlier_thresh, method, tree_distance_representation,
+                  outlier_thresh, cluster_method, distance_method, tree_distance_representation,
                   sort_matrix, min_members=2):
     (allele_map, df) = process_profile(output_files[PROFILE_KEY], column_mapping={})
     l, p = convert_profiles(df)
@@ -343,12 +350,19 @@ def process_group(group_id, output_files, id_col, group_col, thresholds,
 
     if len(l) >= min_members:
         # compute distances
-        calc_distances_hamming(p, l, p, l, output_files['parquet_matrix'], len(l))
+        if distance_method == SCALED_DISTANCE:
+            calc_distances_scaled(p, l, p, l, output_files['parquet_matrix'], len(l))
+        elif distance_method == HAMMING_DISTANCE:
+            calc_distances_hamming(p, l, p, l, output_files['parquet_matrix'], len(l))
+        else:
+            message = f"Unrecognized distance method: {distance_method}"
+            raise Exception(message)
+
         pq.ParquetFile(output_files['parquet_matrix']).to_pandas().to_csv(output_files['matrix'], index=False, header=True,
                                                                           sep="\t")
 
         # perform clustering
-        mc = multi_level_clustering(output_files['matrix'], thresholds, method, sort_matrix, tree_distances=tree_distance_representation)
+        mc = multi_level_clustering(output_files['matrix'], thresholds, cluster_method, sort_matrix, tree_distances=tree_distance_representation)
         memberships = mc.get_memberships()
         with open(output_files['tree'], 'w') as fh:
             fh.write(f"{mc.newick}\n")
@@ -514,7 +528,7 @@ def cluster_reporter(config):
     outdir = config[OUTDIR_KEY]
     outlier_thresh = config[OUTLIER_THRESHOLD_KEY]
     thresholds = config[THRESHOLDS_KEY]
-    method = config[CLUSTER_METHOD_KEY]
+    cluster_method = config[CLUSTER_METHOD_KEY]
     tree_distance_representation = config[TREE_DISTANCES_KEY]
     force = config[FORCE_KEY]
     sort_matrix = config[SORT_MATRIX_KEY]
@@ -523,11 +537,11 @@ def cluster_reporter(config):
     min_members = config[MINIMUM_MEMBERS_KEY]
     num_threads = config[THREADS_KEY]
     restrict_output = config[ONLY_REPORT_LABELED_KEY]
+    distance_method = config[DISTANCE_METHOD_KEY]
 
     # Unused parameters:
     skip_qc = config[SKIP_QC_KEY]
     missing_thresh = config[MISSING_THRESHOLD_KEY]
-    distm = config[DISTANCE_METHOD_KEY]
     count_missing = config[COUNT_MISSING_KEY]
     delimiter = config[DELIMITER_KEY]
 
@@ -539,9 +553,6 @@ def cluster_reporter(config):
 
     if(missing_thresh):
         print(f'WARNING: missing threshold ({MISSING_THRESHOLD_LONG}) was provided, but this parameter is currently unused.')
-
-    if(distm):
-        print(f'WARNING: distance method ({DISTANCE_METHOD_LONG}) was provided, but this parameter is currently unused.')
 
     # See above comment for skip_qc.
     if(count_missing):
@@ -620,8 +631,8 @@ def cluster_reporter(config):
 
     thresholds = process_thresholds(thresholds)
 
-    if not method in CLUSTER_METHODS:
-        message = f'Linkage method supplied is invalid: {method}, it needs to be one of average, single, complete'
+    if not cluster_method in CLUSTER_METHODS:
+        message = f'Linkage method supplied is invalid: {cluster_method}, it needs to be one of average, single, complete'
         raise Exception(message)
 
     if not isinstance(min_members, int):
@@ -704,7 +715,7 @@ def cluster_reporter(config):
         fh.write(json.dumps(run_data['threshold_map'], indent=4))
 
     group_files = stage_data(groups, outdir, metadata_df, id_col, group_file_mapping, max_missing_frac=1)
-    results = process_data(group_files, id_col, partition_col, thresholds, outlier_thresh, method, min_members, tree_distance_representation, sort_matrix, num_cpus=num_threads)
+    results = process_data(group_files, id_col, partition_col, thresholds, outlier_thresh, cluster_method, distance_method, min_members, tree_distance_representation, sort_matrix, num_cpus=num_threads)
     group_metrics = {}
     for r in results:
         for k in r:

--- a/tests/data/config_scaled_thresholds.json
+++ b/tests/data/config_scaled_thresholds.json
@@ -1,0 +1,25 @@
+{
+    "outlier_thresh": "50",
+    "method": "average",
+    "thresholds": "40,30,20,10,0",
+    "min_members": 2,
+    "partition_col": "cluster_id",
+    "id_col": "sample_id",
+    "only_report_labeled_columns": "False",
+    
+    "grouped_metadata_columns":{ 
+        "cluster_id":{ "data_type": "None","label":"OutbreakID","default":"","display":"True"},  
+        "country":{ "data_type": "categorical","label":"Country of collection","default":"","display":"False"},
+        "organism":{ "data_type": "categorical","label":"Species","default":"","display":"False"}, 
+        "score":{ "data_type": "desc_stats","label":"Score","default":"","display":"False"}, 
+        "state/province":{ "data_type": "categorical","label":"State or Province","default":"","display":"False"}
+    },
+
+    "linelist_columns":{
+        "sample_id":{ "data_type": "None","label":"Identifier","default":"","display":"True"},  
+        "cluster_id":{ "data_type": "None","label":"OutbreakID","default":"","display":"True"},  
+        "country":{ "data_type": "categorical","label":"Country of collection","default":"","display":"True"},
+        "state/province":{ "data_type": "categorical","label":"State or Province","default":"","display":"True"}, 
+        "organism":{ "data_type": "categorical","label":"Species","default":"","display":"False"}
+    }
+}

--- a/tests/data/config_specify_warning_parameters.json
+++ b/tests/data/config_specify_warning_parameters.json
@@ -8,7 +8,7 @@
     "only_report_labeled_columns": "False",
     "skip_qc": "True",
     "missing_thresh": 5,
-    "distm": "scaled",
+    "distm": "hamming",
     "count_missing": "True",
     "delimiter": ".",
     

--- a/tests/test-workflows.yml
+++ b/tests/test-workflows.yml
@@ -416,13 +416,12 @@
   tags:
     - parameter_warnings
     - parameter_warnings_command_line
-  command: arborator --profile tests/data/profile.tsv --metadata tests/data/metadata.tsv --config tests/data/config_no_global_parameters.json --outdir results --skip_qc --missing_thresh 5 --distm scaled --count_missing --delimiter "."  --outlier_thresh 25 -e average --thresholds 10,5,2,1,0 --min_members 2 --partition_col cluster_id --id_col sample_id
+  command: arborator --profile tests/data/profile.tsv --metadata tests/data/metadata.tsv --config tests/data/config_no_global_parameters.json --outdir results --skip_qc --missing_thresh 5 --distm hamming --count_missing --delimiter "."  --outlier_thresh 25 -e average --thresholds 10,5,2,1,0 --min_members 2 --partition_col cluster_id --id_col sample_id
   exit_code: 0
   stdout:
     contains:
       - "WARNING: skip QC (--skip_qc/-s) was provided, but this parameter is currently unused."
       - "WARNING: missing threshold (--missing_thresh) was provided, but this parameter is currently unused."
-      - "WARNING: distance method (--distm) was provided, but this parameter is currently unused."
       - "WARNING: count missing (--count_missing/-n) was provided, but this parameter is currently unused."
       - "WARNING: delimiter (--delimiter/-d) was provided, but this parameter is currently unused."
 
@@ -436,7 +435,6 @@
     contains:
       - "WARNING: skip QC (--skip_qc/-s) was provided, but this parameter is currently unused."
       - "WARNING: missing threshold (--missing_thresh) was provided, but this parameter is currently unused."
-      - "WARNING: distance method (--distm) was provided, but this parameter is currently unused."
       - "WARNING: count missing (--count_missing/-n) was provided, but this parameter is currently unused."
       - "WARNING: delimiter (--delimiter/-d) was provided, but this parameter is currently unused."
 

--- a/tests/test-workflows.yml
+++ b/tests/test-workflows.yml
@@ -2188,3 +2188,127 @@
         - "S4\tS4\t2\t\t\t\t\t\t\t\t"
         - "S5\tS5\t3\t\t\t\t\t\t\t\t"
         - "S6\tS6\tunassociated\t\t\t\t\t\t\t\t"
+
+- name: Basic Hamming
+  tags:
+    - basic_hamming
+  command: arborator --profile tests/data/profile.tsv --metadata tests/data/metadata.tsv --config tests/data/config.json --outdir results --distm hamming
+  stdout:
+    must_not_contain:
+      - "parameter unrecognized"
+  files:
+    - path: "results/cluster_summary.tsv"
+      contains:
+        - "OutbreakID\tcount_country_Australia\tcount_country_Canada\tcount_country_United Kingdom\tcount_country_United States\tcount_host_chicken\tcount_host_human\tcount_members\tcount_organism_Salmonella enterica\tcount_outliers\tcount_state/province_British Columbia\tcount_state/province_California\tcount_state/province_England\tcount_state/province_NSW\tcount_state/province_New York\tcount_state/province_Ontario\thost\tmax_dist\tmean_dist\tmedian_dist\tmin_dist\toutlier_ids\tscore_max_value\tscore_mean_value\tscore_median_value\tscore_min_value"
+        - "1\t3\t2\t0\t0\t3\t2\t5\t5\t0\t1\t0\t0\t3\t0\t1\tchicken,human\t2.0\t1.5\t2.0\t0.0\t\t1.0\t1.0\t1.0\t1.0"
+        - "2\t0\t0\t0\t2\t2\t0\t2\t2\t0\t0\t1\t0\t0\t1\t0\tchicken\t1.0\t1.0\t1.0\t1.0\t\t2.0\t1.5\t1.5\t1.0"
+        - "3\t0\t2\t0\t0\t1\t1\t2\t2\t0\t1\t0\t0\t0\t0\t1\tchicken,human\t1.0\t1.0\t1.0\t1.0\t\t4.0\t3.5\t3.5\t3.0"
+        - "4\t0\t0\t0\t2\t0\t2\t2\t2\t0\t0\t0\t0\t0\t2\t0\thuman\t1.0\t1.0\t1.0\t1.0\t\t5.0\t3.5\t3.5\t2.0"
+        - "5\t0\t0\t2\t0\t0\t2\t2\t2\t0\t0\t0\t2\t0\t0\t0\thuman\t1.0\t1.0\t1.0\t1.0\t\t1.0\t1.0\t1.0\t1.0"
+    - path: "results/1/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "A\t1|1.1.1.1.1"
+        - "B\t1|1.1.1.1.2"
+        - "K\t1|1.1.1.2.3"
+        - "L\t1|1.1.1.2.4"
+        - "M\t1|1.1.1.1.1"
+    - path: "results/2/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "C\t2|1.1.1.1.1"
+        - "D\t2|1.1.1.1.2"
+    - path: "results/3/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "E\t3|1.1.1.1.1"
+        - "F\t3|1.1.1.1.2"
+    - path: "results/4/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "G\t4|1.1.1.1.1"
+        - "H\t4|1.1.1.1.2"
+    - path: "results/5/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "I\t5|1.1.1.1.1"
+        - "J\t5|1.1.1.1.2"
+    - path: "results/1/matrix.tsv"
+      contains:
+        - "dists\tA\tB\tK\tL\tM"
+        - "A\t0\t1\t2\t2\t0"
+        - "B\t1\t0\t2\t2\t1"
+        - "K\t2\t2\t0\t1\t2"
+        - "L\t2\t2\t1\t0\t2"
+        - "M\t0\t1\t2\t2\t0"
+    - path: "results/run.json"
+      contains:
+        - '"partition_col": "cluster_id"'
+        - '"id_col": "sample_id"'
+        - '"method": "average"'
+        - '"thresholds": "10,5,2,1,0"'
+        - '"distm": "hamming"'
+    - path: "results/cluster_summary.xlsx"
+    - path: "results/metadata.included.xlsx"
+
+- name: Basic Scaled
+  tags:
+    - basic_scaled
+  command: arborator --profile tests/data/profile.tsv --metadata tests/data/metadata.tsv --config tests/data/config_scaled_thresholds.json --outdir results --distm scaled
+  stdout:
+    must_not_contain:
+      - "parameter unrecognized"
+  files:
+    - path: "results/cluster_summary.tsv"
+      contains:
+        - "OutbreakID\tcount_country_Australia\tcount_country_Canada\tcount_country_United Kingdom\tcount_country_United States\tcount_host_chicken\tcount_host_human\tcount_members\tcount_organism_Salmonella enterica\tcount_outliers\tcount_state/province_British Columbia\tcount_state/province_California\tcount_state/province_England\tcount_state/province_NSW\tcount_state/province_New York\tcount_state/province_Ontario\thost\tmax_dist\tmean_dist\tmedian_dist\tmin_dist\toutlier_ids\tscore_max_value\tscore_mean_value\tscore_median_value\tscore_min_value"
+        - "1\t3\t2\t0\t0\t3\t2\t5\t5\t0\t1\t0\t0\t3\t0\t1\tchicken,human\t28.571428571428573\t21.42857142857143\t28.571428571428573\t0.0\t\t1.0\t1.0\t1.0\t1.0"
+        - "2\t0\t0\t0\t2\t2\t0\t2\t2\t0\t0\t1\t0\t0\t1\t0\tchicken\t14.285714285714286\t14.285714285714286\t14.285714285714286\t14.285714285714286\t\t2.0\t1.5\t1.5\t1.0"
+        - "3\t0\t2\t0\t0\t1\t1\t2\t2\t0\t1\t0\t0\t0\t0\t1\tchicken,human\t14.285714285714286\t14.285714285714286\t14.285714285714286\t14.285714285714286\t\t4.0\t3.5\t3.5\t3.0"
+        - "4\t0\t0\t0\t2\t0\t2\t2\t2\t0\t0\t0\t0\t0\t2\t0\thuman\t14.285714285714286\t14.285714285714286\t14.285714285714286\t14.285714285714286\t\t5.0\t3.5\t3.5\t2.0"
+        - "5\t0\t0\t2\t0\t0\t2\t2\t2\t0\t0\t0\t2\t0\t0\t0\thuman\t14.285714285714286\t14.285714285714286\t14.285714285714286\t14.285714285714286\t\t1.0\t1.0\t1.0\t1.0"
+    - path: "results/1/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "A\t1|1.1.1.1.1"
+        - "B\t1|1.1.1.2.2"
+        - "K\t1|1.1.2.3.3"
+        - "L\t1|1.1.2.4.4"
+        - "M\t1|1.1.1.1.1"
+    - path: "results/2/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "C\t2|1.1.1.1.1"
+        - "D\t2|1.1.1.2.2"
+    - path: "results/3/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "E\t3|1.1.1.1.1"
+        - "F\t3|1.1.1.2.2"
+    - path: "results/4/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "G\t4|1.1.1.1.1"
+        - "H\t4|1.1.1.2.2"
+    - path: "results/5/clusters.tsv"
+      contains:
+        - "sample_id\tgas_denovo_cluster_address"
+        - "I\t5|1.1.1.1.1"
+        - "J\t5|1.1.1.2.2"
+    - path: "results/1/matrix.tsv"
+      contains:
+        - "dists\tA\tB\tK\tL\tM"
+        - "A\t0.0\t14.285714285714286\t28.571428571428573\t28.571428571428573\t0.0"
+        - "B\t14.285714285714286\t0.0\t28.571428571428573\t28.571428571428573\t14.285714285714286"
+        - "K\t28.571428571428573\t28.571428571428573\t0.0\t14.285714285714286\t28.571428571428573"
+        - "L\t28.571428571428573\t28.571428571428573\t14.285714285714286\t0.0\t28.571428571428573"
+        - "M\t0.0\t14.285714285714286\t28.571428571428573\t28.571428571428573\t0.0"
+    - path: "results/run.json"
+      contains:
+        - '"partition_col": "cluster_id"'
+        - '"id_col": "sample_id"'
+        - '"method": "average"'
+        - '"thresholds": "40,30,20,10,0"'
+        - '"distm": "scaled"'
+    - path: "results/cluster_summary.xlsx"
+    - path: "results/metadata.included.xlsx"


### PR DESCRIPTION
**Description**

As a data analyst, I would like to be able to select between hamming and scaled distance comparisons in arborator so that I can adjust how I am comparing genomes.

**Acceptance Criteria**

- [x] Support for "scaled" distance comparisons in arborator software (https://github.com/phac-nml/arborator)
  - [x] While there is a parameter "--distm" for changing distance methods, this parameter currently does not work and hamming distance is always chosen.
  - [x] Should fix "--distm" so it can be used to select between "scaled" and "hamming"
- [x] Add tests for both distance comparison methods.
- [x] Update documentation for both distance comparison methods.
- [ ] Release new version of arborator with support for both distance methods
  - [ ] Release on GitHub
  - [ ] Release as PyPI package
  - [ ] Update Bioconda package

**Note**

The scaled distance function is pulled from profile_dists and has code that writes messages to standard error:

https://github.com/phac-nml/profile_dists/blob/bb917a9d3c8b4de994bb4c4d16f324510e8ab146/profile_dists/utils.py#L533-L540

and this shows up in the output for Arborator:

```
arborator --profile tests/data/profile.tsv --metadata tests/data/metadata.tsv --config tests/data/config_scaled_thresholds.json --outdir results --distm scaled --force
4 batch
write
1 batch
write
1 batch
write
1 batch
write
1 batch
write
```

If we don't want this to happen, it'll need to be fixed directly in profile_dists.

Addresses #13